### PR TITLE
Require at least Ruby 1.9.2

### DIFF
--- a/redis-browser.gemspec
+++ b/redis-browser.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">=1.9.2"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 


### PR DESCRIPTION
Fixes https://github.com/monterail/redis-browser/issues/8.

Ruby 1.8 doesn't support `{key: "value"}` notation.
It only supports `{:key => "value"}` notation.

See http://stackoverflow.com/a/8014115.